### PR TITLE
Updated deprecated php functions.

### DIFF
--- a/src/turkeyweather.php
+++ b/src/turkeyweather.php
@@ -18,10 +18,22 @@ class TurkeyWeather{
 
 	private function getData(){ // Bilgileri mgm.gov.tr den getirir
 
-		// türkçe karakterleri her ihtimale karşı değiştiriyor
-		$province = str_replace(['Ç','ç','ı','İ','Ğ','ğ','Ö','ö','Ü','ü','ş','Ş','â','Â'], ['c','c','i','i','g','g','o','o','u','u','s','s','a','a'], $this->province_name);
-		$district = str_replace(['Ç','ç','ı','İ','Ğ','ğ','Ö','ö','Ü','ü','ş','Ş','â','Â'], ['c','c','i','i','g','g','o','o','u','u','s','s','a','a'], $this->district_name);
-
+		// türkçe karakterleri her ihtimale karşı değiştiriyor,
+		$province = $district = "";
+		
+		if (!empty($this->province_name)) {
+			$province = iconv('UTF-8', 'ASCII//TRANSLIT', $this->province_name);
+		} else {
+			$province = '';
+		}
+		
+		if (!empty($this->district_name)) {
+			$district = iconv('UTF-8', 'ASCII//TRANSLIT', $this->district_name);
+		} else {
+			$district = '';
+		}
+		
+		
 		$targetLocation = "https://servis.mgm.gov.tr/web/merkezler?il=" . $province . '&ilce=' . $district; // İl ve İlçe bilgilerini getirir. ilçe yoksa veya yanlışsa mgm sitesindeki varsayılan ilçe için sonuçları getirir. Örn. Ankara için keçiören ilçesi
 		$weatherNow = "https://servis.mgm.gov.tr/web/sondurumlar?merkezid="; // Hava durumunu getiren URL. merkezid değerini daha elde etmediğimiz için yazılmadı
 		$curl = curl_init();


### PR DESCRIPTION
Deprecated function: str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated.

To prevent this error I updated the turkeyweather-api library to check if the variables are empty and if not then it replaces chars using the iconv('UTF-8', 'ASCII//TRANSLIT', $this->variableName); function.

iconv replaces the chars to the closest ascii representation of the input char.
It is not a good practice to write every nonAscii char one by one.


//Türkçe

Deprecated function: str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated.

Bu hatayı önlemek için turkeyweather-api dosyası içinde değişkenlerin boş olup olmadığını kontrol edecek şekilde güncelledim ve boş değilse, iconv('UTF-8', 'ASCII//TRANSLIT', $this->variableName);  fonksiyonu ile karakterleri çeviriyor.

iconv, karakterleri giriş karakterinin en yakın ascii temsiliyle değiştirir.
Ascii olmayan her karakteri tek tek yazmak iyi bir uygulama değil.